### PR TITLE
Add autobuild workflow action

### DIFF
--- a/.github/workflows/autobuild-stable.yml
+++ b/.github/workflows/autobuild-stable.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download Everest stripped lib
+      uses: robinraju/release-downloader@v1.2
+      with:
+        repository: EverestAPI/Everest
+        tag: stable-1.3164.0
+        fileName: lib-stripped.zip
+     
+    - name: Extract lib-stripped.zip
+      run: unzip lib-stripped.zip
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    - name: Restore with .NET Core
+      run: dotnet restore
+
+    - name: Build with .NET Core
+      run: dotnet build "/p:Configuration=Debug"
+      env:
+        CELESTEGAMEPATH: ${{ github.workspace }}/lib-stripped
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: main
+        path: bin/Debug/net452

--- a/.github/workflows/autobuild-stable.yml
+++ b/.github/workflows/autobuild-stable.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Parse Everest Dependency
       run: |
-        EVERESTDEP=$(sed -n -e '/Everest$/{n;s/Version: //;p}' everest.yaml | xargs)
+        EVERESTDEP=$(yq -r '.[0].Dependencies[] | select(.Name == "Everest").Version' everest.yaml)
         echo "EVERESTDEP=$EVERESTDEP" >> $GITHUB_ENV
 
     - name: Download Everest stripped lib

--- a/.github/workflows/autobuild-stable.yml
+++ b/.github/workflows/autobuild-stable.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Parse Everest Dependency
       run: |
-        EVERESTDEP=$(yq -r '.[0].Dependencies[] | select(.Name == "Everest").Version' everest.yaml)
+        EVERESTDEP=$(yq -r '.[0].Dependencies[] | select(.Name == "Everest").Version' -- everest.yaml)
         echo "EVERESTDEP=$EVERESTDEP" >> $GITHUB_ENV
 
     - name: Download Everest stripped lib

--- a/.github/workflows/autobuild-stable.yml
+++ b/.github/workflows/autobuild-stable.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Parse Everest Dependency
       run: |
-        EVERESTDEP=$(yq -r '.[0].Dependencies[] | select(.Name == "Everest").Version' -- everest.yaml)
+        EVERESTDEP=$(yq eval '.[0].Dependencies[] | select(.Name == "Everest").Version' -- everest.yaml)
         echo "EVERESTDEP=$EVERESTDEP" >> $GITHUB_ENV
 
     - name: Download Everest stripped lib

--- a/.github/workflows/autobuild-stable.yml
+++ b/.github/workflows/autobuild-stable.yml
@@ -8,11 +8,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Parse Everest Dependency
+      run: |
+        EVERESTDEP=$(sed -n -e '/Everest$/{n;s/Version: //;p}' everest.yaml | xargs)
+        echo "EVERESTDEP=$EVERESTDEP" >> $GITHUB_ENV
+
     - name: Download Everest stripped lib
       uses: robinraju/release-downloader@v1.2
       with:
         repository: EverestAPI/Everest
-        tag: stable-1.3164.0
+        tag: stable-${{ env.EVERESTDEP }}
         fileName: lib-stripped.zip
      
     - name: Extract lib-stripped.zip

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download Everest stripped lib
+      uses: coloursofnoise/get-azure-pipelines-artifact@v0.0.3
+      with:
+        repository: EverestAPI/Everest
+        definitionId: 3
+        artifact: lib-stripped
+        reasonFilter: 'individualCI'
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    - name: Restore with .NET Core
+      run: dotnet restore
+
+    - name: Build with .NET Core
+      run: dotnet build "/p:Configuration=Debug"
+      env:
+        CELESTEGAMEPATH: ${{ github.workspace }}/lib-stripped
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: main
+        path: bin/Debug/net452

--- a/ExampleMod.csproj
+++ b/ExampleMod.csproj
@@ -16,8 +16,8 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonoMod" Version="21.4.29.1" />
-    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.01.11.01" />
+    <PackageReference Include="MonoMod" Version="21.08.19.01" />
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.08.19.01" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExampleMod.csproj
+++ b/ExampleMod.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Example</AssemblyName>
     <RootNamespace>Celeste.Mod.Example</RootNamespace>
     <LangVersion>7.3</LangVersion>
+    <CelesteGamePath Condition="'$(CELESTEGAMEPATH)' == ''">..\..</CelesteGamePath>
   </PropertyGroup>
 
   <!--Disable "Copy Local" for all references-->
@@ -20,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Celeste" HintPath="..\..\Celeste.exe" />
-    <Reference Include="MMHOOK_Celeste" HintPath="..\..\MMHOOK_Celeste.dll" />
-    <Reference Include="YamlDotNet" HintPath="..\..\YamlDotNet.dll" />
+    <Reference Include="Celeste" HintPath="$(CELESTEGAMEPATH)\Celeste.exe" />
+    <Reference Include="MMHOOK_Celeste" HintPath="$(CELESTEGAMEPATH)\MMHOOK_Celeste.dll" />
+    <Reference Include="YamlDotNet" HintPath="$(CELESTEGAMEPATH)\YamlDotNet.dll" />
   </ItemGroup>
 
   <Choose>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build](https://github.com/EverestAPI/ExampleMod/actions/workflows/autobuild.yml/badge.svg)](https://github.com/EverestAPI/ExampleMod/actions/workflows/autobuild.yml)
+
 __The purpose of this mod is to provide a comprehensive example of an Everest code mod.__
 
 The goal is to show and document every feature that is available for code modders, provided that it is not already covered in general-purpose language and framework tutorials.

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,4 +3,4 @@
   DLL: bin/Debug/net452/Example.dll
   Dependencies:
     - Name: Everest
-      Version: 1.0.0
+      Version: 1.3164.0


### PR DESCRIPTION
Adds a build on push workflow using GitHub Actions.

Makes use of new `lib-stripped` Everest artifact, currently handled through a fork of the [get-azure-pipelines-artifact](https://github.com/git-for-windows/get-azure-pipelines-artifact) action while waiting for a functionality PR to be merged.

Adds the `CELESTEGAMEPATH` environment variable to use in the .csproj file when resolving references.